### PR TITLE
Layout/Sidebar: add support of Gravatar to fetch main picture

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -96,6 +96,9 @@ canonifyURLs = true
   # This appears at the top of the sidebar above params.intro.header.
   # A width of less than 100px is recommended from a design perspective.
   [params.intro.pic]
+    # Gravatar email to use to fetch the picture. This will override the `src`
+    # field if set.
+    gravatar  = ""
     src       = "/img/main/logo.jpg"
     # Sets Image to be a cirlce
     circle    = false

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -5,12 +5,18 @@
   <section id="intro">
     {{ $pic := .Site.Params.intro.pic }}
     {{ with $pic.src }}
+      {{ $.Scratch.Set "picURL" (. | relURL )}}
+    {{ end }}
+    {{ with $pic.gravatar }}
+      {{ $.Scratch.Set "picURL" (printf "https://www.gravatar.com/avatar/%s?s=100&d=identicon" (. | md5) )}}
+    {{ end }}
+    {{ with $.Scratch.Get "picURL" }}
       {{ if $pic.circle }}
-        <a href='{{"/" | relURL}}'><img src="{{ . | relURL }}" class="intro-circle" width="{{ $pic.width }}" alt="{{ $pic.alt }}" /></a>
+        <a href='{{"/" | relURL}}'><img src="{{ $.Scratch.Get "picURL" }}" class="intro-circle" width="{{ $pic.width }}" alt="{{ $pic.alt }}" /></a>
       {{ else if $pic.imperfect }}
-        <a href='{{"/" | relURL}}' class="logo"><img src="{{ . | relURL }}" alt="{{ $pic.alt }}" /></a>
+        <a href='{{"/" | relURL}}' class="logo"><img src="{{ $.Scratch.Get "picURL" }}" alt="{{ $pic.alt }}" /></a>
       {{ else }}
-        <a href='{{"/" | relURL}}'><img src="{{ . | relURL }}" width="{{ $pic.width }}" alt="{{ $pic.alt }}" /></a>
+        <a href='{{"/" | relURL}}'><img src="{{ $.Scratch.Get "picURL" }}" width="{{ $pic.width }}" alt="{{ $pic.alt }}" /></a>
       {{ end }}
     {{ end }}
     {{ with .Site.Params.intro }}


### PR DESCRIPTION
This PR has also been submitted upstream (you'll find more details there): jpescador/hugo-future-imperfect#130

It's getting merged on `master` here in my fork because maintaining such long lived branches is tedious and I need to get each of my modifications in a single place.